### PR TITLE
v1.6.0 - RenderService<T> calls SKCanvas.Flush()

### DIFF
--- a/BassClefStudio.SkiaSharp.Helpers/BassClefStudio.SkiaSharp.Helpers.csproj
+++ b/BassClefStudio.SkiaSharp.Helpers/BassClefStudio.SkiaSharp.Helpers.csproj
@@ -6,7 +6,7 @@
     <Description>Helper classes for building graphical applications and games using SkiaSharp.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/SkiaSharp-Helpers</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/SkiaSharp-Helpers.git</RepositoryUrl>
-    <Version>1.5.2</Version>
+    <Version>1.6.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/BassClefStudio.SkiaSharp.Helpers/RenderService.cs
+++ b/BassClefStudio.SkiaSharp.Helpers/RenderService.cs
@@ -53,6 +53,8 @@ namespace BassClefStudio.SkiaSharp.Helpers
             canvas.Translate(-ViewCamera.CameraPosition.X, -ViewCamera.CameraPosition.Y);
 
             RenderInternal(canvas);
+
+            canvas.Flush();
         }
 
         /// <summary>


### PR DESCRIPTION
This commit adds the pushing of content to the `SKCanvas` through the `Render()` method by default on all RenderService calls. Should close #2.